### PR TITLE
fix: make proposal dedupe portable in Actions runner

### DIFF
--- a/.github/workflows/agent-issue-proposals.yml
+++ b/.github/workflows/agent-issue-proposals.yml
@@ -59,7 +59,7 @@ jobs:
             body="$(jq -r ".[$i].body" tmp/issue_proposals.json)"
             labels="$(jq -r ".[$i].labels | join(\",\")" tmp/issue_proposals.json)"
 
-            if printf '%s\n' "${existing_titles}" | rg -xF -- "${title}" >/dev/null; then
+            if printf '%s\n' "${existing_titles}" | grep -Fx -- "${title}" >/dev/null; then
               echo "Skipping duplicate: ${title}"
               continue
             fi


### PR DESCRIPTION
Replace `rg` with `grep -Fx` in proposal dedupe logic so GitHub-hosted runners correctly skip existing issue titles.

<!-- render-preview-link:start -->
Render preview: https://auto-codex-web-pr-29.onrender.com
<!-- render-preview-link:end -->
